### PR TITLE
Fix regression: ${pageTitle} in title (#8)

### DIFF
--- a/monolithic/monolithic-layered/src/main/java/com/epam/training/microservices/monolithic/web/delivery/DeliveryController.java
+++ b/monolithic/monolithic-layered/src/main/java/com/epam/training/microservices/monolithic/web/delivery/DeliveryController.java
@@ -43,7 +43,7 @@ public class DeliveryController implements ViewAllSupport<Delivery>, ViewSingleD
     @Override
     public ViewSingleDetailsTemplateParams getViewSingleTemplateParams(Delivery parent) {
         return ViewSingleDetailsTemplateParams.builder()
-                .title("Edit delivery")
+                .title("Edit Delivery")
                 .field(new HiddenFieldModel("id", "id"))
                 .field(new TextFieldModel("Address", "addressLine"))
                 .field(new TextFieldModel("Status", "status"))

--- a/monolithic/monolithic-layered/src/main/resources/templates/common/single/details.html
+++ b/monolithic/monolithic-layered/src/main/resources/templates/common/single/details.html
@@ -2,7 +2,7 @@
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" xmlns:th="http://www.w3.org/1999/xhtml"
       layout:decorate="~{/template.html}">
 <head>
-    <title>${pageTitle}</title>
+    <title th:text="${pageTitle}"></title>
 </head>
 <body>
 <div th:fragment="details">

--- a/monolithic/monolithic-layered/src/main/resources/templates/common/single/item.html
+++ b/monolithic/monolithic-layered/src/main/resources/templates/common/single/item.html
@@ -2,7 +2,7 @@
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" xmlns:th="http://www.w3.org/1999/xhtml"
       layout:decorate="~{/template.html}">
 <head>
-    <title>${pageTitle}</title>
+    <title th:text="${pageTitle}"></title>
 </head>
 <body>
 

--- a/monolithic/monolithic-layered/src/main/resources/templates/common/single/item_details.html
+++ b/monolithic/monolithic-layered/src/main/resources/templates/common/single/item_details.html
@@ -2,7 +2,7 @@
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" xmlns:th="http://www.w3.org/1999/xhtml"
       layout:decorate="~{/template.html}">
 <head>
-    <title>${pageTitle}</title>
+    <title th:text="${pageTitle}"></title>
 </head>
 <body>
 <section layout:fragment="custom-content">

--- a/monolithic/monolithic-layered/src/main/resources/templates/common/single/item_only.html
+++ b/monolithic/monolithic-layered/src/main/resources/templates/common/single/item_only.html
@@ -2,7 +2,7 @@
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" xmlns:th="http://www.w3.org/1999/xhtml"
       layout:decorate="~{/template.html}">
 <head>
-    <title>${pageTitle}</title>
+    <title th:text="${pageTitle}"></title>
 </head>
 <body>
 <section layout:fragment="custom-content">

--- a/monolithic/monolithic-layered/src/test/java/com/epam/training/microservices/monolithic/web/delivery/DeliveryControllerIT.java
+++ b/monolithic/monolithic-layered/src/test/java/com/epam/training/microservices/monolithic/web/delivery/DeliveryControllerIT.java
@@ -35,9 +35,9 @@ public class DeliveryControllerIT extends MockMvcTest {
         MockHttpServletRequestBuilder editDeliveryReq = get("/delivery/1");
         this.mockMvc.perform(editDeliveryReq)
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("<title>The Drug System - Delivery</title>")))
-                .andExpect(content().string(containsString("<h1>Edit Delivery</h1>")))
-                .andExpect(content().string(containsString("<input type=\"hidden\" id=\"id\" name=\"id\" value=\"1\" />")))
+                .andExpect(content().string(containsString("<title>The Drug System - Edit Delivery</title>")))
+                .andExpect(content().string(containsString(">Edit Delivery</h1>")))
+                .andExpect(content().string(containsString("<input type=\"hidden\" id=\"id\" name=\"id\" value=\"1\"")))
                 .andExpect(content().string(containsString("1 Cherokee Hill")))
                 .andExpect(content().string(containsString("<button type=\"submit\" class=\"btn btn-primary\">Save</button>")))
                 .andExpect(content().string(containsString("<a href=\"/delivery\" class=\"btn btn-link\">Back</a>")));


### PR DESCRIPTION
This PR fixes #8 again after it was broken in #34. Tests in `main` (before this fix) are clearly indicating that there's a problem with page title for some pages.

![image](https://github.com/aabarmin/epam-microservices-training-2022/assets/3858548/df233e7f-e277-4591-9ca3-afb29872cc11)
